### PR TITLE
feat: Google OAuth 로그인 연동

### DIFF
--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { supabase } from "@/lib/supabase";
+
+export default function AuthCallbackPage() {
+  const router = useRouter();
+
+  useEffect(() => {
+    supabase.auth.onAuthStateChange((event) => {
+      if (event === "SIGNED_IN") {
+        router.push("/");
+      }
+    });
+  }, [router]);
+
+  return (
+    <div className="flex items-center justify-center min-h-[60vh]">
+      <p className="text-gray-500">로그인 처리 중...</p>
+    </div>
+  );
+}

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -8,12 +8,14 @@ import { useAuth } from "@/contexts/AuthContext";
 
 export default function LoginPage() {
   const { lang } = useLang();
-  const { signIn } = useAuth();
+  const { signIn, signInWithGoogle } = useAuth();
   const router = useRouter();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
+
+  const [googleLoading, setGoogleLoading] = useState(false);
 
   const t = {
     ko: {
@@ -23,6 +25,8 @@ export default function LoginPage() {
       submit: "로그인",
       noAccount: "계정이 없으신가요?",
       signUp: "회원가입",
+      googleLogin: "Google로 로그인",
+      or: "또는",
     },
     en: {
       title: "Sign In",
@@ -31,6 +35,8 @@ export default function LoginPage() {
       submit: "Sign In",
       noAccount: "Don't have an account?",
       signUp: "Sign Up",
+      googleLogin: "Sign in with Google",
+      or: "OR",
     },
   };
   const c = t[lang];
@@ -54,6 +60,38 @@ export default function LoginPage() {
   return (
     <div className="max-w-sm mx-auto px-6 py-24">
       <h1 className="text-3xl font-bold text-gray-900 mb-8 text-center">{c.title}</h1>
+
+      {/* Google Login */}
+      <button
+        onClick={async () => {
+          setGoogleLoading(true);
+          const err = await signInWithGoogle();
+          if (err) {
+            setError(err);
+            setGoogleLoading(false);
+          }
+        }}
+        disabled={googleLoading}
+        className="w-full flex items-center justify-center gap-3 py-3 border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50 transition-colors mb-6"
+      >
+        <svg className="w-5 h-5" viewBox="0 0 24 24">
+          <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"/>
+          <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
+          <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
+          <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
+        </svg>
+        <span className="text-sm font-medium text-gray-700">
+          {googleLoading ? "..." : c.googleLogin}
+        </span>
+      </button>
+
+      {/* Divider */}
+      <div className="flex items-center gap-4 mb-6">
+        <div className="flex-1 h-px bg-gray-200" />
+        <span className="text-xs text-gray-400">{c.or}</span>
+        <div className="flex-1 h-px bg-gray-200" />
+      </div>
+
       <form onSubmit={handleSubmit} className="space-y-4">
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-1">{c.email}</label>

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -10,6 +10,7 @@ type AuthState = {
   loading: boolean;
   signIn: (email: string, password: string) => Promise<string | null>;
   signUp: (email: string, password: string) => Promise<string | null>;
+  signInWithGoogle: () => Promise<string | null>;
   signOut: () => Promise<void>;
 };
 
@@ -47,12 +48,22 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return error ? error.message : null;
   }
 
+  async function signInWithGoogle(): Promise<string | null> {
+    const { error } = await supabase.auth.signInWithOAuth({
+      provider: "google",
+      options: {
+        redirectTo: `${window.location.origin}/auth/callback`,
+      },
+    });
+    return error ? error.message : null;
+  }
+
   async function signOut() {
     await supabase.auth.signOut();
   }
 
   return (
-    <AuthContext.Provider value={{ user, session, loading, signIn, signUp, signOut }}>
+    <AuthContext.Provider value={{ user, session, loading, signIn, signUp, signInWithGoogle, signOut }}>
       {children}
     </AuthContext.Provider>
   );


### PR DESCRIPTION
## Summary
- 로그인 페이지에 "Google로 로그인" 버튼 추가
- AuthContext에 `signInWithGoogle()` 함수 추가 (Supabase OAuth)
- OAuth 콜백 처리 페이지 `/auth/callback` 생성
- 한국어/영어 이중 언어 지원

## 활성화 필요사항
Google OAuth가 실제 작동하려면:
1. Supabase Dashboard > Authentication > Providers > Google 활성화
2. Google Cloud Console에서 OAuth 2.0 Client ID 생성
3. Redirect URL: `https://xysplleobrcyyqiuxbeu.supabase.co/auth/v1/callback`

## Test plan
- [x] `next build` 성공
- [x] Google 버튼 UI 표시
- [x] 기존 이메일 로그인 정상 작동
- [ ] Google OAuth 플로우 (Provider 활성화 후 테스트)

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)